### PR TITLE
linagora/linagora-private#16: Remove proxy from webpack-dev-server

### DIFF
--- a/webpack.commons.js
+++ b/webpack.commons.js
@@ -16,7 +16,6 @@ const pugLoaderOptions = {
 };
 
 const BASE_HREF = process.env.BASE_HREF || '/';
-const OPENPAAS_URL = process.env.OPENPAAS_URL || 'http://localhost:8080';
 
 module.exports = {
   entry: './src/index.js',
@@ -96,39 +95,7 @@ module.exports = {
     host: '0.0.0.0',
     disableHostCheck: true,
     port: 9900,
-    historyApiFallback: true,
-    proxy: [
-      {
-        context: [
-          '/auth',
-          '/api',
-          '/logout',
-          '/views',
-          '/account/api',
-          '/profile/app',
-          '/controlcenter/app',
-          '/images',
-          '/socket.io/',
-          '/user-status/app/bubble/',
-          '/user-status/api',
-          '/contact/app',
-          '/contact/images',
-          '/dav/api',
-          '/unifiedinbox/views',
-          '/unifiedinbox/app',
-          '/unifiedinbox/api',
-          '/calendar/app',
-          '/calendar/api',
-          '/linagora.esn.resource/api',
-          '/linagora.esn.linshare/api'
-        ],
-        target: OPENPAAS_URL,
-        disableHostCheck: true,
-        secure: true,
-        changeOrigin: true,
-        withCredentials: true
-      }
-    ]
+    historyApiFallback: true
   },
   module: {
     rules: [


### PR DESCRIPTION
Using proxy is not relevant anymore as we set the backend URL in env