### PR TITLE
Hide bar on composer with summernote 0.8.18

### DIFF
--- a/src/linagora.esn.unifiedinbox/app/components/composer/body-editor/html/composer-body-editor-html.less
+++ b/src/linagora.esn.unifiedinbox/app/components/composer/body-editor/html/composer-body-editor-html.less
@@ -114,7 +114,7 @@ inbox-composer-body-editor-html.esn-summernote {
       }
     }
 
-    .note-resizebar {
+    .note-status-ouput, .note-statusbar {
       display: none;
     }
 


### PR DESCRIPTION
Needed because summernote will be upgraded to 0.8.18, see https://github.com/linagora/esn-frontend-common-libs/pull/256

Before
![image](https://user-images.githubusercontent.com/550970/153432139-90053f27-fe48-4f54-8abe-8b675e14b7e1.png)

After
![image](https://user-images.githubusercontent.com/550970/153432476-e3a4c27d-dcb3-422d-b474-7db409a3bd1a.png)
