### PR TITLE
Partial fix to newlines added when pasting HTML

### DIFF
--- a/src/linagora.esn.unifiedinbox/app/components/composer/body-editor/html/composer-body-editor-html.controller.js
+++ b/src/linagora.esn.unifiedinbox/app/components/composer/body-editor/html/composer-body-editor-html.controller.js
@@ -70,7 +70,7 @@ angular.module('linagora.esn.unifiedinbox')
       }
       e.preventDefault();
 
-      const cleanHtml = htmlCleaner.clean(pastedHtml);
+      const cleanHtml = htmlCleaner.clean(pastedHtml).replaceAll(/[\n\r]/g, '');
 
       $element.find('.summernote').summernote('pasteHTML', cleanHtml);
     }


### PR DESCRIPTION
Related to #523
Tests with summernote 0.8.18 (seems to not work with previous version)

Before
![image](https://user-images.githubusercontent.com/550970/153571626-6610493f-8f34-42e7-ba98-ca161405ec51.png)
![image](https://user-images.githubusercontent.com/550970/153571680-7174cf20-ab2f-4fdb-a82c-57c4b8838b4a.png)

After
![image](https://user-images.githubusercontent.com/550970/153571913-df5b7b00-2ac5-42df-aaaf-606d9d90396c.png)
![image](https://user-images.githubusercontent.com/550970/153571986-8b1c458c-19aa-4278-a7f6-e5a3df088cd6.png)
